### PR TITLE
Add account-type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
     		<version>4.6.1</version>
     		<scope>test</scope>
 		</dependency>
+		<dependency>
+    		<groupId>org.springframework.security</groupId>
+    		<artifactId>spring-security-taglibs</artifactId>
+    		<version>5.7.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/linkedmein/entity/Role.java
+++ b/src/main/java/com/example/linkedmein/entity/Role.java
@@ -1,0 +1,45 @@
+package com.example.linkedmein.entity;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "Role")
+public class Role {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+	
+	private String name;
+	
+	@ManyToMany(mappedBy = "roles")
+	private Set<User> users = new HashSet<>();
+	
+	public Role() {
+		// default constructor
+	}
+	
+	public Role(String name) {
+		this.name = name;
+	}
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/src/main/java/com/example/linkedmein/entity/User.java
+++ b/src/main/java/com/example/linkedmein/entity/User.java
@@ -1,12 +1,19 @@
 package com.example.linkedmein.entity;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
@@ -45,6 +52,14 @@ public class User {
 	
 	@Column(name = "reset_password_token", length = 30)
 	private String resetPasswordToken;
+	
+	@ManyToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@JoinTable(
+			name = "users_roles",
+			joinColumns = @JoinColumn(name = "user_id"),
+			inverseJoinColumns = @JoinColumn(name = "role_id")
+			)
+	private Set<Role> roles = new HashSet<>();
 	
 	// Generate Getters and Setters
 	public Integer getId() {
@@ -136,5 +151,14 @@ public class User {
 	}
 	public void setPosts(List<Post> posts) {
 		this.posts = posts;
+	}
+	public Set<Role> getRoles() {
+		return roles;
+	}
+	public void addRoles(Role role) {
+		this.roles.add(role);
+	}
+	public void removeRoles(Role role) {
+		this.roles.remove(role);
 	}
 }

--- a/src/main/java/com/example/linkedmein/repository/RoleRepository.java
+++ b/src/main/java/com/example/linkedmein/repository/RoleRepository.java
@@ -1,0 +1,14 @@
+package com.example.linkedmein.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.example.linkedmein.entity.Role;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Integer> {
+	
+	@Query("SELECT r FROM Role r WHERE r.name = :name")
+	public Role findRolebyName(String name);
+}

--- a/src/main/java/com/example/linkedmein/service/CustomUserDetails.java
+++ b/src/main/java/com/example/linkedmein/service/CustomUserDetails.java
@@ -1,11 +1,16 @@
 package com.example.linkedmein.service;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import com.example.linkedmein.entity.Role;
 import com.example.linkedmein.entity.User;
 
 public class CustomUserDetails implements UserDetails {
@@ -18,8 +23,14 @@ public class CustomUserDetails implements UserDetails {
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		// TODO Auto-generated method stub
-		return null;
+		Set<Role> roles = user.getRoles();
+		List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+		
+		for(Role role : roles) {
+			authorities.add(new SimpleGrantedAuthority(role.getName()));
+		}
+		
+		return authorities;
 	}
 
 	@Override

--- a/src/main/webapp/WEB-INF/jsp/components/navbar.jsp
+++ b/src/main/webapp/WEB-INF/jsp/components/navbar.jsp
@@ -44,6 +44,13 @@
                                 	<i class="fa-solid fa-table-columns"></i>
                                 	Jobs Posting</a>
                                 </li>
+                                <%@ taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
+                                <sec:authorize access="hasAuthority('ADMIN')">
+                                <li><a class="dropdown-item" href="/users">
+                                	<i class="fa-solid fa-table-columns"></i>
+                                	Manage Users</a>
+                                </li>
+                                </sec:authorize>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                 	<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>

--- a/src/test/java/com/example/linkedmein/UserRepositoryTest.java
+++ b/src/test/java/com/example/linkedmein/UserRepositoryTest.java
@@ -2,6 +2,9 @@ package com.example.linkedmein;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -11,16 +14,21 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.annotation.Rollback;
 
+import com.example.linkedmein.entity.Role;
 import com.example.linkedmein.entity.User;
+import com.example.linkedmein.repository.RoleRepository;
 import com.example.linkedmein.repository.UserRepository;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Rollback(true)
+@Rollback(false)
 public class UserRepositoryTest {
 	
 	@Autowired
 	private UserRepository userRepository;
+	
+	@Autowired
+	private RoleRepository roleRepository;
 	
 	@Autowired
 	private TestEntityManager em;
@@ -68,5 +76,31 @@ public class UserRepositoryTest {
 		User existedUser = userRepository.findUserByUsername("foo");
 		
 		assertThat(existedUser.getUsername()).isEqualTo(savedUser.getUsername());
+	}
+	
+	@Test
+	public void test_create_user_roles() {
+		Role role_admin = new Role("ADMIN");
+		Role role_user = new Role("USER");
+		
+		roleRepository.saveAll(List.of(role_user, role_admin));
+	}
+	
+	@Test
+	public void test_add_roles_to_user() {
+		User user_admin = userRepository.findUserByEmail("hadrihilmi@gmail.com");
+		
+		if(user_admin != null) {
+			Role USER = roleRepository.getReferenceById(9);
+			Role ADMIN = roleRepository.getReferenceById(10);
+			
+			user_admin.addRoles(ADMIN);
+			user_admin.addRoles(USER);
+			userRepository.save(user_admin);
+		}
+		
+		Set<Role> roles = user_admin.getRoles();
+		
+		assertThat(roles.size()).isEqualTo(roleRepository.findAll().size());
 	}
 }


### PR DESCRIPTION
this pr proposed a simple role-based authorization, where two (2) account-type is defined: 
1) USER
2) ADMIN

To demonstrate a working account-type, a simple link on navbar called `Manage Users` can only be seen by account-type `ADMIN`. 

![screenshot](https://i.postimg.cc/brbB1y7T/Untitled.png)